### PR TITLE
fix(tui-big-text): Add support for rendering all available fonts with `BigText`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
-          tool: cargo-semver-checks@0.48
+          tool: cargo-semver-checks@0.49
       - name: Run cargo-semver-checks
         run: cargo semver-checks --workspace
 

--- a/tui-big-text/examples/README.md
+++ b/tui-big-text/examples/README.md
@@ -4,6 +4,10 @@
 
 ![tui-big-text Demo](https://vhs.charm.sh/vhs-7DFJFGwBEnUjjLCFSqwEm9.gif)
 
+## Non-ASCII Fonts
+
+![Non-ASCII font demo](https://vhs.charm.sh/vhs-6wHS9dZJTj3rOjVFeV3Ty9.gif)
+
 ## Alignment
 
 ![Alignment Demo](https://vhs.charm.sh/vhs-2GdJCPpXfnOCTsykSPr7AW.gif)

--- a/tui-big-text/examples/non_ascii.rs
+++ b/tui-big-text/examples/non_ascii.rs
@@ -1,4 +1,4 @@
-//! Renders a basic `BigText` widget with non-ASCII text.
+//! Demonstrates rendering non-ASCII fonts with Hiragana and Greek text.
 //!
 //! Run with `cargo run -p tui-big-text --example non_ascii`.
 //!
@@ -28,7 +28,7 @@ fn run(terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
 }
 
 fn render(frame: &mut Frame) {
-    let title = Line::from("tui-big-text demo. <q> quit").cyan();
+    let title = Line::from("tui-big-text non-ASCII demo. <q> quit").cyan();
 
     let big_text = BigText::builder()
         .centered()

--- a/tui-big-text/examples/non_ascii.rs
+++ b/tui-big-text/examples/non_ascii.rs
@@ -31,9 +31,10 @@ fn render(frame: &mut Frame) {
     let title = Line::from("tui-big-text demo. <q> quit").cyan();
 
     let big_text = BigText::builder()
+        .centered()
         .pixel_size(tui_big_text::PixelSize::HalfHeight)
         .lines(vec![
-            "にほんごのひらがな".white().on_red().into(),
+            "ひらがな".white().on_red().into(),
             "ελληνικά".white().on_blue().into(),
         ])
         .build();

--- a/tui-big-text/examples/non_ascii.rs
+++ b/tui-big-text/examples/non_ascii.rs
@@ -1,0 +1,46 @@
+//! Renders a basic `BigText` widget with non-ASCII text.
+//!
+//! Run with `cargo run -p tui-big-text --example non_ascii`.
+//!
+//! Press `q` or `Esc` to quit.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::layout::Offset;
+use ratatui::prelude::{Frame, Stylize};
+use ratatui::text::Line;
+use tui_big_text::BigText;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    ratatui::run(run)
+}
+
+fn run(terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
+    loop {
+        terminal.draw(render)?;
+        if let Some(key) = event::read()?.as_key_press_event()
+            && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+        {
+            break Ok(());
+        }
+    }
+}
+
+fn render(frame: &mut Frame) {
+    let title = Line::from("tui-big-text demo. <q> quit").cyan();
+
+    let big_text = BigText::builder()
+        .pixel_size(tui_big_text::PixelSize::HalfHeight)
+        .lines(vec![
+            "にほんごのひらがな".white().on_red().into(),
+            "ελληνικά".white().on_blue().into(),
+        ])
+        .build();
+
+    let area = frame.area();
+    frame.render_widget(title, area);
+
+    let area = area.offset(Offset { x: 0, y: 2 }).intersection(area);
+    frame.render_widget(big_text, area);
+}

--- a/tui-big-text/examples/non_ascii.tape
+++ b/tui-big-text/examples/non_ascii.tape
@@ -1,0 +1,14 @@
+# VHS Tape (see https://github.com/charmbracelet/vhs)
+Output "target/non_ascii.gif"
+Set Theme "Aardvark Blue"
+Set Width 1200
+Set Height 400
+Hide
+Type@0 "cargo run -p tui-big-text --example non_ascii --quiet"
+Enter
+Sleep 2s
+Show
+Screenshot "target/non_ascii.png"
+Sleep 1s
+Hide
+Escape

--- a/tui-big-text/examples/non_ascii.tape
+++ b/tui-big-text/examples/non_ascii.tape
@@ -1,8 +1,9 @@
 # VHS Tape (see https://github.com/charmbracelet/vhs)
+# Non-ASCII font demo
 Output "target/non_ascii.gif"
 Set Theme "Aardvark Blue"
-Set Width 1200
-Set Height 400
+Set Width 1000
+Set Height 420
 Hide
 Type@0 "cargo run -p tui-big-text --example non_ascii --quiet"
 Enter

--- a/tui-big-text/examples/stopwatch.rs
+++ b/tui-big-text/examples/stopwatch.rs
@@ -303,8 +303,12 @@ impl EventHandler {
                 KeyCode::Char('s') | KeyCode::Enter => Message::Stop,
                 _ => Message::Tick,
             }),
-            Some(Err(err)) => bail!(err),
-            None => bail!("event stream ended unexpectedly"),
+            Some(Err(err)) => {
+                bail!(err);
+            }
+            None => {
+                bail!("event stream ended unexpectedly");
+            }
             _ => Ok(Message::Tick),
         }
     }

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -188,14 +188,13 @@ fn get_alignment_offset<'a>(
     }
 }
 
-const FONTS: [&dyn UnicodeFonts; 9] = [
+const FONTS: [&dyn UnicodeFonts; 8] = [
     &font8x8::BASIC_FONTS,
     &font8x8::LATIN_FONTS,
     &font8x8::HIRAGANA_FONTS,
     &font8x8::GREEK_FONTS,
     &font8x8::BLOCK_FONTS,
     &font8x8::BOX_FONTS,
-    &font8x8::HIRAGANA_FONTS,
     &font8x8::MISC_FONTS,
     &font8x8::SGA_FONTS,
 ];

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -180,8 +180,11 @@ fn get_alignment_offset<'a>(
     alignment: Alignment,
     line: &'a Line<'a>,
 ) -> u16 {
-    let line_char_count: usize = line.iter().map(|f| f.content.chars().count()).sum();
-    let big_line_width = line_char_count as u16 * letter_width;
+    // Each grapheme occupies one fixed-width bitmap area in the rendered layout.
+    let line_glyph_count = line.styled_graphemes(Style::default()).count();
+    let big_line_width = line_glyph_count
+        .saturating_mul(usize::from(letter_width))
+        .clamp(0, usize::from(u16::MAX)) as u16;
     match alignment {
         Alignment::Center => (area_width / 2).saturating_sub(big_line_width / 2),
         Alignment::Right => area_width.saturating_sub(big_line_width),
@@ -200,16 +203,13 @@ const FONTS: [&dyn UnicodeFonts; 8] = [
     &font8x8::SGA_FONTS,
 ];
 
-/// Render a single grapheme into a cell by looking up the corresponding 8x8 bitmap in the
-/// all of the available fonts and setting the corresponding cells in the buffer.
+/// Render a single grapheme into a cell by looking up the corresponding 8x8 bitmap in all of the
+/// available fonts and setting the corresponding cells in the buffer.
 fn render_symbol(grapheme: StyledGrapheme, area: Rect, buf: &mut Buffer, pixel_size: &PixelSize) {
     buf.set_style(area, grapheme.style);
     let c = grapheme.symbol.chars().next().unwrap(); // TODO: handle multi-char graphemes
-    for font in FONTS {
-        if let Some(glyph) = font.get(c) {
-            render_glyph(glyph, area, buf, pixel_size);
-            break;
-        }
+    if let Some(glyph) = FONTS.iter().find_map(|font| font.get(c)) {
+        render_glyph(glyph, area, buf, pixel_size);
     }
 }
 
@@ -1178,6 +1178,64 @@ mod tests {
             "          ▀▀▀▘▝▀▘ ▀ ▀ ▝▀▘ ▀▀▘           ",
         ]);
         assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn render_hiragana_font() {
+        let big_text = BigText::builder()
+            .lines(vec![Line::from("ひらがな")])
+            .build();
+        let mut buf = Buffer::empty(Rect::new(0, 0, 32, 8));
+
+        big_text.render(buf.area, &mut buf);
+
+        let expected = Buffer::with_lines(vec![
+            "         ████     █   █  █  ██  ",
+            "                  █  █   █      ",
+            "██  █    █      ████    ███  █  ",
+            " █  ██   █ ███    █ █ █  █   █  ",
+            "█   █ █  ██   █  █  █ █  █  ███ ",
+            "█   █    █    █  █  █ █ █  █ █  ",
+            " ███        ██  █  █    █   █   ",
+            "                                ",
+        ]);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn render_greek_font() {
+        let big_text = BigText::builder()
+            .lines(vec![Line::from("ελληνικά")])
+            .build();
+        let mut buf = Buffer::empty(Rect::new(0, 0, 64, 8));
+
+        big_text.render(buf.area, &mut buf);
+
+        let expected = Buffer::with_lines(vec![
+            "                                                            ███ ",
+            "        ██      ██                                              ",
+            " ████    ██      ██     █████   ██  ██    ██    ██  ██   ███ ██ ",
+            "██        ██      ██    ██  ██  ██  ██    ██    ██ ██   ██ ███  ",
+            " ███      ███     ███   ██  ██  ██  ██    ██    ████    ██  █   ",
+            "██       ██ ██   ██ ██  ██  ██   ████     ██ █  ██ ██   ██ ███  ",
+            " ████   ██   ██ ██   ██ ██  ██    ██       ██   ██  ██   ███ ██ ",
+            "                            ██                                  ",
+        ]);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn centered_hiragana_uses_glyph_count_for_alignment() {
+        let line = Line::from("ひらがな");
+
+        assert_eq!(get_alignment_offset(80, 8, Alignment::Center, &line), 24);
+    }
+
+    #[test]
+    fn alignment_width_clamps_to_u16_max() {
+        let line = Line::from("x".repeat(usize::from(u16::MAX) + 1));
+
+        assert_eq!(get_alignment_offset(80, 1, Alignment::Center, &line), 0);
     }
 
     #[test]

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -204,10 +204,10 @@ const FONTS: [&dyn UnicodeFonts; 8] = [
 fn render_symbol(grapheme: StyledGrapheme, area: Rect, buf: &mut Buffer, pixel_size: &PixelSize) {
     buf.set_style(area, grapheme.style);
     let c = grapheme.symbol.chars().next().unwrap(); // TODO: handle multi-char graphemes
-    for font in FONTS {   
+    for font in FONTS {
         if let Some(glyph) = font.get(c) {
             render_glyph(glyph, area, buf, pixel_size);
-            break
+            break;
         }
     }
 }

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -188,13 +188,28 @@ fn get_alignment_offset<'a>(
     }
 }
 
+const FONTS: [&dyn UnicodeFonts; 9] = [
+    &font8x8::BASIC_FONTS,
+    &font8x8::LATIN_FONTS,
+    &font8x8::HIRAGANA_FONTS,
+    &font8x8::GREEK_FONTS,
+    &font8x8::BLOCK_FONTS,
+    &font8x8::BOX_FONTS,
+    &font8x8::HIRAGANA_FONTS,
+    &font8x8::MISC_FONTS,
+    &font8x8::SGA_FONTS,
+];
+
 /// Render a single grapheme into a cell by looking up the corresponding 8x8 bitmap in the
-/// `BITMAPS` array and setting the corresponding cells in the buffer.
+/// all of the available fonts and setting the corresponding cells in the buffer.
 fn render_symbol(grapheme: StyledGrapheme, area: Rect, buf: &mut Buffer, pixel_size: &PixelSize) {
     buf.set_style(area, grapheme.style);
     let c = grapheme.symbol.chars().next().unwrap(); // TODO: handle multi-char graphemes
-    if let Some(glyph) = font8x8::BASIC_FONTS.get(c) {
-        render_glyph(glyph, area, buf, pixel_size);
+    for font in FONTS {   
+        if let Some(glyph) = font.get(c) {
+            render_glyph(glyph, area, buf, pixel_size);
+            break
+        }
     }
 }
 

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -180,7 +180,8 @@ fn get_alignment_offset<'a>(
     alignment: Alignment,
     line: &'a Line<'a>,
 ) -> u16 {
-    let big_line_width = line.width() as u16 * letter_width;
+    let line_char_count: usize = line.iter().map(|f| f.content.chars().count()).sum();
+    let big_line_width = line_char_count as u16 * letter_width;
     match alignment {
         Alignment::Center => (area_width / 2).saturating_sub(big_line_width / 2),
         Alignment::Right => area_width.saturating_sub(big_line_width),


### PR DESCRIPTION
The `BigText` widget would only use the `BasicFont` provided by `font8x8`. However, there are numerous other fonts that can render the glyphs, such as Hiragana etc.

This changes `render_symbol` to iterate over all the available fonts rather than only doing a lookup against `font8x8::BASIC_FONTS`.

Also added an example and a VHS tape for demo purposes.

<img width="1200" height="400" alt="non_ascii" src="https://github.com/user-attachments/assets/9a3dd054-fb32-4070-92d1-0055bcef04b7" />

Doing this exposed a bug with how the line widths are calculated and therefore how the text alignment worked.

In `get_alignment_offset`, the "line width" (i.e. character count) was actually just using the underlying byte width, not the number of characters. This has been changed to simply sum the number of characters from each span of the line.